### PR TITLE
[cscore] Add UVC Protocol Support for USB Camera Controls on macOS

### DIFF
--- a/cscore/CMakeLists.txt
+++ b/cscore/CMakeLists.txt
@@ -21,7 +21,7 @@ if(APPLE)
         cscore
         PROPERTIES
             LINK_FLAGS
-                "-framework CoreFoundation -framework AVFoundation -framework Foundation -framework CoreMedia -framework CoreVideo"
+                "-framework CoreFoundation -framework AVFoundation -framework Foundation -framework CoreMedia -framework CoreVideo -framework IOKit"
     )
 elseif(MSVC)
     target_sources(cscore PRIVATE ${cscore_windows_src})

--- a/cscore/build.gradle
+++ b/cscore/build.gradle
@@ -11,17 +11,6 @@ ext {
 // with no support.
 if (OperatingSystem.current().isMacOsX()) {
     apply plugin: 'objective-cpp'
-    model {
-        toolChains {
-            clang(Clang) {
-                eachPlatform {
-                    linker.withArguments { args ->
-                        args << '-framework' << 'IOKit'
-                    }
-                }
-            }
-        }
-    }
 }
 
 apply from: "${rootDir}/shared/jni/setupBuild.gradle"

--- a/cscore/build.gradle
+++ b/cscore/build.gradle
@@ -11,6 +11,17 @@ ext {
 // with no support.
 if (OperatingSystem.current().isMacOsX()) {
     apply plugin: 'objective-cpp'
+    model {
+        toolChains {
+            clang(Clang) {
+                eachPlatform {
+                    linker.withArguments { args ->
+                        args << '-framework' << 'IOKit'
+                    }
+                }
+            }
+        }
+    }
 }
 
 apply from: "${rootDir}/shared/jni/setupBuild.gradle"

--- a/cscore/src/main/native/objcpp/UsbCameraImpl.h
+++ b/cscore/src/main/native/objcpp/UsbCameraImpl.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <string>
 #include <optional>
+#include <map>
 
 #include "SourceImpl.h"
 
@@ -88,8 +89,33 @@ class UsbCameraImpl : public SourceImpl {
 
   UsbCameraImplObjc* cppGetObjc() { return m_objc; }
 
+  int CreatePropertyPublic(std::string_view name, std::function<std::unique_ptr<PropertyImpl>()> newFunc) {
+    return CreateProperty(name, newFunc);
+  }
+
+  PropertyImpl* GetPropertyPublic(int property) {
+    return GetProperty(property);
+  }
+
+  void NotifyPropertyCreatedPublic(int propIndex, PropertyImpl& prop) {
+    NotifyPropertyCreated(propIndex, prop);
+  }
+
+  void UpdatePropertyValuePublic(int property, bool setString, int value, std::string_view valueStr) {
+    UpdatePropertyValue(property, setString, value, valueStr);
+  }
+
+  wpi::mutex& GetMutex() { return m_mutex; }
+
+  // Property cache accessors
+  std::map<std::string, uint32_t>& GetPropertyCache() { return m_propertyCache; }
+  std::map<std::string, uint32_t>& GetPropertyAutoCache() { return m_propertyAutoCache; }
+
  private:
   UsbCameraImplObjc* m_objc;
   std::vector<CameraModeStore> m_platformModes;
+  // Property caches
+  std::map<std::string, uint32_t> m_propertyCache;
+  std::map<std::string, uint32_t> m_propertyAutoCache;
 };
 }  // namespace cs

--- a/cscore/src/main/native/objcpp/UsbCameraImpl.h
+++ b/cscore/src/main/native/objcpp/UsbCameraImpl.h
@@ -114,6 +114,7 @@ class UsbCameraImpl : public SourceImpl {
  private:
   UsbCameraImplObjc* m_objc;
   std::vector<CameraModeStore> m_platformModes;
+  
   // Property caches
   std::map<std::string, uint32_t> m_propertyCache;
   std::map<std::string, uint32_t> m_propertyAutoCache;

--- a/cscore/src/main/native/objcpp/UsbCameraImplObjc.h
+++ b/cscore/src/main/native/objcpp/UsbCameraImplObjc.h
@@ -35,6 +35,7 @@
 #define kPropertyAutoExposure "exposure_auto"
 #define kPropertyAutoWhiteBalance "white_balance_automatic"
 #define kPropertyAutoFocus "focus_auto"
+
 namespace cs {
 class UsbCameraImpl;
 }

--- a/cscore/src/main/native/objcpp/UsbCameraImplObjc.h
+++ b/cscore/src/main/native/objcpp/UsbCameraImplObjc.h
@@ -5,11 +5,13 @@
 #pragma once
 
 #import <AVFoundation/AVFoundation.h>
-#import "UsbCameraDelegate.h"
-#import "UvcControlImpl.h"
 
 #include <memory>
 #include <string_view>
+
+#import "UsbCameraDelegate.h"
+#import "UvcControlImpl.h"
+
 #include "cscore_cpp.h"
 
 // Quirk: exposure auto is 3 for on, 1 for off

--- a/cscore/src/main/native/objcpp/UsbCameraImplObjc.h
+++ b/cscore/src/main/native/objcpp/UsbCameraImplObjc.h
@@ -6,10 +6,11 @@
 
 #import <AVFoundation/AVFoundation.h>
 #import "UsbCameraDelegate.h"
+#import "UvcControlImpl.h"
+
 #include <memory>
 #include <string_view>
 #include "cscore_cpp.h"
-
 namespace cs {
 class UsbCameraImpl;
 }
@@ -30,6 +31,7 @@ class UsbCameraImpl;
 @property(nonatomic) AVCaptureDevice* videoDevice;
 @property(nonatomic) AVCaptureDeviceInput* videoInput;
 @property(nonatomic) UsbCameraDelegate* callback;
+@property(nonatomic) UvcControlImpl* uvcControl;
 @property(nonatomic) AVCaptureVideoDataOutput* videoOutput;
 @property(nonatomic) AVCaptureSession* session;
 

--- a/cscore/src/main/native/objcpp/UsbCameraImplObjc.h
+++ b/cscore/src/main/native/objcpp/UsbCameraImplObjc.h
@@ -11,6 +11,30 @@
 #include <memory>
 #include <string_view>
 #include "cscore_cpp.h"
+
+// Quirk: exposure auto is 3 for on, 1 for off
+#define kPropertyAutoExposureOn 3
+#define kPropertyAutoExposureOff 1
+
+// Property names
+#define kPropertyBrightness "brightness"
+#define kPropertyWhiteBalance "white_balance_temperature"
+#define kPropertyExposure "raw_exposure_time_absolute"
+#define kPropertyContrast "raw_contrast"
+#define kPropertySaturation "raw_saturation"
+#define kPropertySharpness "raw_sharpness"
+#define kPropertyGain "gain"
+#define kPropertyGamma "gamma"
+#define kPropertyHue "raw_hue"
+#define kPropertyFocus "focus_absolute"
+#define kPropertyZoom "zoom"
+#define kPropertyBackLightCompensation "backlight_compensation"
+#define kPropertyPowerLineFrequency "power_line_frequency"
+
+// Auto property names
+#define kPropertyAutoExposure "exposure_auto"
+#define kPropertyAutoWhiteBalance "white_balance_automatic"
+#define kPropertyAutoFocus "focus_auto"
 namespace cs {
 class UsbCameraImpl;
 }

--- a/cscore/src/main/native/objcpp/UsbCameraImplObjc.h
+++ b/cscore/src/main/native/objcpp/UsbCameraImplObjc.h
@@ -70,4 +70,8 @@ class UsbCameraImpl;
 - (void)getCameraName:(std::string*)name;
 - (void)setNewCameraPath:(std::string_view*)path;
 
+- (void)deviceCacheProperties;
+- (void)cacheProperty:(uint32_t)propID withName:(NSString *)name;
+- (void)cacheAutoProperty:(uint32_t)propID withName:(NSString *)baseName;
+
 @end

--- a/cscore/src/main/native/objcpp/UsbCameraImplObjc.mm
+++ b/cscore/src/main/native/objcpp/UsbCameraImplObjc.mm
@@ -5,10 +5,10 @@
 #include <wpi/SmallString.h>
 
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+#import "UsbCameraImplObjc.h"
+
 #include "Notifier.h"
 #include "Log.h"
-
-#import "UsbCameraImplObjc.h"
 #include "UsbCameraImpl.h"
 
 template <typename S, typename... Args>
@@ -886,6 +886,8 @@ static cs::VideoMode::PixelFormat FourCCToPixelFormat(FourCharCode fourcc) {
       nearestDuration = maxDuration;
     }
   }
+
+  OBJCDEBUG("Nearest fps: {}", nearestDuration.timescale / static_cast<double>(nearestDuration.value));
   
   return nearestDuration;
 }
@@ -1009,9 +1011,10 @@ static cs::VideoMode::PixelFormat FourCCToPixelFormat(FourCharCode fourcc) {
   self.uvcControl = [UvcControlImpl createFromAVCaptureDevice:self.videoDevice status:&status];
   if (self.uvcControl == nil) {
     OBJCWARNING("Failed to initialize UVC control for camera: {}", status);
+  } else {
+    OBJCINFO("UVC control initialized successfully");
   }
   
-  OBJCINFO("UVC control initialized successfully");
   self.uvcControl.cppImpl = self.cppImpl;
 
   self.callback = [[UsbCameraDelegate alloc] init];

--- a/cscore/src/main/native/objcpp/UsbCameraImplObjc.mm
+++ b/cscore/src/main/native/objcpp/UsbCameraImplObjc.mm
@@ -135,10 +135,44 @@ using namespace cs;
   *status = CS_INVALID_PROPERTY;
 }
 - (void)setExposureAuto:(CS_Status*)status {
-  *status = CS_INVALID_PROPERTY;
+  dispatch_async_and_wait(self.sessionQueue, ^{
+    if (self.videoDevice == nil) {
+      *status = CS_READ_FAILED;
+      return;
+    }
+    
+    if ([self.videoDevice lockForConfiguration:nil]) {
+      if ([self.videoDevice isExposureModeSupported:AVCaptureExposureModeContinuousAutoExposure]) {
+        self.videoDevice.exposureMode = AVCaptureExposureModeContinuousAutoExposure;
+        *status = CS_OK;
+      } else {
+        *status = CS_UNSUPPORTED_MODE;
+      }
+      [self.videoDevice unlockForConfiguration];
+    } else {
+      *status = CS_READ_FAILED;
+    }
+  });
 }
 - (void)setExposureHoldCurrent:(CS_Status*)status {
-  *status = CS_INVALID_PROPERTY;
+  dispatch_async_and_wait(self.sessionQueue, ^{
+    if (self.videoDevice == nil) {
+      *status = CS_READ_FAILED;
+      return;
+    }
+    
+    if ([self.videoDevice lockForConfiguration:nil]) {
+      if ([self.videoDevice isExposureModeSupported:AVCaptureExposureModeLocked]) {
+        self.videoDevice.exposureMode = AVCaptureExposureModeLocked;
+        *status = CS_OK;
+      } else {
+        *status = CS_UNSUPPORTED_MODE;
+      }
+      [self.videoDevice unlockForConfiguration];
+    } else {
+      *status = CS_READ_FAILED;
+    }
+  });
 }
 - (void)setExposureManual:(int)value status:(CS_Status*)status {
   *status = CS_INVALID_PROPERTY;

--- a/cscore/src/main/native/objcpp/UsbCameraImplObjc.mm
+++ b/cscore/src/main/native/objcpp/UsbCameraImplObjc.mm
@@ -69,10 +69,10 @@ inline void NamedLog(UsbCameraImplObjc* objc, unsigned int level,
   OBJCLOG(::wpi::WPI_LOG_DEBUG4, format __VA_OPT__(, ) __VA_ARGS__)
 #endif
 
-
 using namespace cs;
 
 @implementation UsbCameraImplObjc
+
 - (void)start {
   switch ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo]) {
     case AVAuthorizationStatusAuthorized:

--- a/cscore/src/main/native/objcpp/UvcControlImpl.h
+++ b/cscore/src/main/native/objcpp/UvcControlImpl.h
@@ -10,6 +10,8 @@
 #import <IOKit/IOKitLib.h>
 #import <IOKit/IOCFPlugIn.h>
 #import <IOKit/usb/IOUSBLib.h>
+#import "UsbCameraDelegate.h"
+
 #include <memory>
 #include <string_view>
 #include "cscore_cpp.h"

--- a/cscore/src/main/native/objcpp/UvcControlImpl.h
+++ b/cscore/src/main/native/objcpp/UvcControlImpl.h
@@ -1,0 +1,129 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+#import <AVFoundation/AVFoundation.h>
+#import <IOKit/usb/USB.h>
+#import <IOKit/IOKitLib.h>
+#import <IOKit/IOCFPlugIn.h>
+#import <IOKit/usb/IOUSBLib.h>
+#include <memory>
+#include <string_view>
+#include "cscore_cpp.h"
+
+// Status code definition
+#define STATUS_OK 0
+#define STATUS_ERROR -1
+#define STATUS_DEVICE_DISCONNECTED -2
+
+// UVC control selector definitions
+#define UVC_INPUT_TERMINAL_ID 0x01
+
+// Camera terminal control selectors
+#define CT_AE_MODE_CONTROL 0x02
+#define CT_AE_PRIORITY_CONTROL 0x03
+#define CT_EXPOSURE_TIME_ABSOLUTE_CONTROL 0x04
+#define CT_EXPOSURE_TIME_RELATIVE_CONTROL 0x05
+#define CT_FOCUS_ABSOLUTE_CONTROL 0x06
+#define CT_FOCUS_RELATIVE_CONTROL 0x07
+#define CT_FOCUS_AUTO_CONTROL 0x08
+#define CT_ZOOM_ABSOLUTE_CONTROL 0x0B
+#define CT_ZOOM_RELATIVE_CONTROL 0x0C
+
+// Processing unit control selectors
+#define PU_BACKLIGHT_COMPENSATION_CONTROL 0x01
+#define PU_BRIGHTNESS_CONTROL 0x02
+#define PU_CONTRAST_CONTROL 0x03
+#define PU_GAIN_CONTROL 0x04
+#define PU_POWER_LINE_FREQUENCY_CONTROL 0x05
+#define PU_HUE_CONTROL 0x06
+#define PU_SATURATION_CONTROL 0x07
+#define PU_SHARPNESS_CONTROL 0x08
+#define PU_GAMMA_CONTROL 0x09
+#define PU_WHITE_BALANCE_TEMPERATURE_CONTROL 0x0A
+#define PU_WHITE_BALANCE_TEMPERATURE_AUTO_CONTROL 0x0B
+#define PU_WHITE_BALANCE_COMPONENT_CONTROL 0x0C
+#define PU_WHITE_BALANCE_COMPONENT_AUTO_CONTROL 0x0D
+#define PU_HUE_AUTO_CONTROL 0x10
+#define PU_CONTRAST_AUTO_CONTROL 0x13
+
+// Camera request error code
+#define VC_REQUEST_ERROR_CODE_CONTROL 0x02
+
+// UVC control interface definitions
+#define UVC_CONTROL_INTERFACE_CLASS 14
+#define UVC_CONTROL_INTERFACE_SUBCLASS 1
+
+// UVC control request types
+#define UVC_SET_CUR 0x01
+#define UVC_GET_CUR 0x81
+#define UVC_GET_MIN 0x82
+#define UVC_GET_MAX 0x83
+#define UVC_GET_RES 0x84
+#define UVC_GET_INFO 0x86
+#define UVC_GET_DEF 0x87
+
+// Camera property ID definitions
+#define CAPPROPID_EXPOSURE 1
+#define CAPPROPID_FOCUS 2
+#define CAPPROPID_ZOOM 3
+#define CAPPROPID_WHITEBALANCE 4
+#define CAPPROPID_GAIN 5
+#define CAPPROPID_BRIGHTNESS 6
+#define CAPPROPID_CONTRAST 7
+#define CAPPROPID_SATURATION 8
+#define CAPPROPID_GAMMA 9
+#define CAPPROPID_HUE 10
+#define CAPPROPID_SHARPNESS 11
+#define CAPPROPID_BACKLIGHTCOMP 12
+#define CAPPROPID_POWERLINEFREQ 13
+#define CAPPROPID_LAST 14
+
+namespace cs {
+class UsbCameraImpl;
+}
+
+@interface UvcControlImpl : NSObject
+
+@property(nonatomic) IOUSBInterfaceInterface190** controlInterface;
+@property(nonatomic) uint32_t processingUnitID;
+@property(nonatomic) std::weak_ptr<cs::UsbCameraImpl> cppImpl;
+
+// Create from AVCaptureDevice
++ (instancetype)createFromAVCaptureDevice:(AVCaptureDevice*)device status:(CS_Status*)status;
+
+// Initialize with USB vendor/product/location
+- (instancetype)initWithVendorId:(uint16_t)vid 
+                      productId:(uint16_t)pid 
+                       location:(uint32_t)location
+                         status:(CS_Status*)status;
+
+- (void)dealloc;
+
+// Basic property control
+- (bool)setProperty:(uint32_t)propID 
+          withValue:(int32_t)value
+             status:(CS_Status*)status;
+- (bool)getProperty:(uint32_t)propID 
+          withValue:(int32_t*)value
+             status:(CS_Status*)status;
+
+// Auto mode control
+- (bool)setAutoProperty:(uint32_t)propID 
+               enabled:(bool)enabled
+                status:(CS_Status*)status;
+- (bool)getAutoProperty:(uint32_t)propID 
+               enabled:(bool*)enabled
+                status:(CS_Status*)status;
+
+// Property range query
+- (bool)getPropertyLimits:(uint32_t)propID
+                     min:(int32_t*)min
+                     max:(int32_t*)max
+                defValue:(int32_t*)defValue
+                  status:(CS_Status*)status;
+
+@end 

--- a/cscore/src/main/native/objcpp/UvcControlImpl.h
+++ b/cscore/src/main/native/objcpp/UvcControlImpl.h
@@ -4,16 +4,15 @@
 
 #pragma once
 
-#import <Foundation/Foundation.h>
 #import <AVFoundation/AVFoundation.h>
-#import <IOKit/usb/USB.h>
-#import <IOKit/IOKitLib.h>
 #import <IOKit/IOCFPlugIn.h>
 #import <IOKit/usb/IOUSBLib.h>
-#import "UsbCameraDelegate.h"
 
 #include <memory>
 #include <string_view>
+
+#import "UsbCameraDelegate.h"
+
 #include "cscore_cpp.h"
 
 // Status code definition

--- a/cscore/src/main/native/objcpp/UvcControlImpl.h
+++ b/cscore/src/main/native/objcpp/UvcControlImpl.h
@@ -15,9 +15,8 @@
 #include "cscore_cpp.h"
 
 // Status code definition
-#define STATUS_OK 0
-#define STATUS_ERROR -1
-#define STATUS_DEVICE_DISCONNECTED -2
+#define CS_UVC_STATUS_ERROR -3001
+#define CS_UVC_STATUS_DEVICE_DISCONNECTED -3002
 
 // UVC control selector definitions
 #define UVC_INPUT_TERMINAL_ID 0x01

--- a/cscore/src/main/native/objcpp/UvcControlImpl.mm
+++ b/cscore/src/main/native/objcpp/UvcControlImpl.mm
@@ -1,0 +1,712 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#import "UvcControlImpl.h"
+#import <AVFoundation/AVFoundation.h>
+
+// USB descriptor for UVC processing unit
+struct ProcessingUnitDescriptor
+{
+    uint8_t bLength;
+    uint8_t bDescriptorType;        // CS_INTERFACE 0x24
+    uint8_t bDescriptorSubtype;     // VC_PROCESSING_UNIT 0x05
+    uint8_t bUnitID;
+};
+
+struct propertyInfo_t
+{
+    uint32_t    selector;   // selector ID
+    uint32_t    unit;       // unit (==0 for INPUT TERMINA:, ==1 for PROCESSING UNIT)
+    uint32_t    length;     // length (bytes)
+};
+
+/** The order of the propertyInfo structure must
+    be the same as the PROPID numbers in the
+    openpnp-capture.h header */
+const propertyInfo_t propertyInfo[] =
+{
+    {0,0,0},
+    {CT_EXPOSURE_TIME_ABSOLUTE_CONTROL   , 0, 4},
+    {CT_FOCUS_ABSOLUTE_CONTROL           , 0, 2},
+    {CT_ZOOM_ABSOLUTE_CONTROL            , 0, 2},
+    {PU_WHITE_BALANCE_TEMPERATURE_CONTROL, 1, 2},
+    {PU_GAIN_CONTROL                     , 1, 2},
+    {PU_BRIGHTNESS_CONTROL               , 1, 2},
+    {PU_CONTRAST_CONTROL                 , 1, 2},
+    {PU_SATURATION_CONTROL               , 1, 2},
+    {PU_GAMMA_CONTROL                    , 1, 2},
+    {PU_HUE_CONTROL                      , 1, 2},
+    {PU_SHARPNESS_CONTROL                , 1, 2},
+    {PU_BACKLIGHT_COMPENSATION_CONTROL   , 1, 2},
+    {PU_POWER_LINE_FREQUENCY_CONTROL     , 1, 1}
+};
+
+@implementation UvcControlImpl {
+    IOUSBDeviceInterface** _deviceInterface;
+}
+
+
++ (instancetype)createFromAVCaptureDevice:(AVCaptureDevice*)device status:(CS_Status*)status {
+    if (!device) {
+        NSLog(@"[UvcControlImpl] device is nil");
+        *status = STATUS_ERROR;
+        return nil;
+    }
+    
+    NSError* error = nil;
+    NSRegularExpression* regex = [NSRegularExpression regularExpressionWithPattern:@"^UVC\\s+Camera\\s+VendorID\\_([0-9]+)\\s+ProductID\\_([0-9]+)$" 
+                                                                         options:0 
+                                                                           error:&error];
+    if (error) {
+        NSLog(@"[UvcControlImpl] failed to create regex: %@", error);
+        *status = STATUS_ERROR;
+        return nil;
+    }
+    
+    NSString* modelID = [device valueForKey:@"modelID"];
+    if (!modelID) {
+        NSLog(@"[UvcControlImpl] modelID is nil");
+        *status = STATUS_ERROR;
+        return nil;
+    }
+    
+    NSTextCheckingResult* match = [regex firstMatchInString:modelID 
+                                                   options:0 
+                                                     range:NSMakeRange(0, modelID.length)];
+    if (!match || match.numberOfRanges != 3) {
+        NSLog(@"[UvcControlImpl] modelID regex match failed");
+        *status = STATUS_ERROR;
+        return nil;
+    }
+    
+    NSString* vendorIDStr = [modelID substringWithRange:[match rangeAtIndex:1]];
+    NSString* productIDStr = [modelID substringWithRange:[match rangeAtIndex:2]];
+    uint16_t vendorID = (uint16_t)strtoul([vendorIDStr UTF8String], NULL, 10);
+    uint16_t productID = (uint16_t)strtoul([productIDStr UTF8String], NULL, 10);
+    
+    uint32_t locationID = 0;
+    CFMutableDictionaryRef dict = IOServiceMatching(kIOUSBDeviceClassName);
+    CFDictionarySetValue(dict, CFSTR("idVendor"), (__bridge CFNumberRef)@(vendorID));
+    CFDictionarySetValue(dict, CFSTR("idProduct"), (__bridge CFNumberRef)@(productID));
+    
+    io_iterator_t iter = 0;
+    kern_return_t ioResult = IOServiceGetMatchingServices(kIOMainPortDefault, dict, &iter);
+    if (ioResult == kIOReturnSuccess) {
+        io_service_t usbDevice = IOIteratorNext(iter);
+        while (usbDevice != 0) {
+            CFTypeRef locationIDRef = IORegistryEntryCreateCFProperty(usbDevice, 
+                                                                    CFSTR("locationID"), 
+                                                                    kCFAllocatorDefault, 
+                                                                    0);
+            if (locationIDRef) {
+                locationID = [(__bridge NSNumber*)locationIDRef unsignedIntValue];
+                CFRelease(locationIDRef);
+                NSString* uniqueID = [device valueForKey:@"uniqueID"];
+                NSString* locationIDHex = [NSString stringWithFormat:@"0x%x", locationID];
+                if ([uniqueID hasPrefix:locationIDHex]) {
+                    IOObjectRelease(usbDevice);
+                    break;
+                }
+            }
+            IOObjectRelease(usbDevice);
+            usbDevice = IOIteratorNext(iter);
+        }
+        IOObjectRelease(iter);
+    }
+    
+    UvcControlImpl *instance = [[UvcControlImpl alloc] initWithVendorId:vendorID 
+                                        productId:productID 
+                                        location:locationID 
+                                           status:status];
+    if (!instance) {
+        NSLog(@"[UvcControlImpl] failed to create UvcControlImpl, status=%d", *status);
+    }
+    return instance;
+}
+
+- (instancetype)initWithVendorId:(uint16_t)vid 
+                      productId:(uint16_t)pid 
+                      location:(uint32_t)location
+                         status:(CS_Status*)status {
+    self = [super init];
+    if (self) {
+        NSLog(@"[UvcControlImpl] Initializing with VID: 0x%04X, PID: 0x%04X, Location: 0x%08X", vid, pid, location);
+        _deviceInterface = [self findDevice:vid productId:pid location:location];
+        if (_deviceInterface == nullptr) {
+            NSLog(@"[UvcControlImpl] Failed to find device");
+            *status = STATUS_DEVICE_DISCONNECTED;
+            return nil;
+        }
+        
+        _processingUnitID = [self getProcessingUnitID:_deviceInterface];
+        NSLog(@"[UvcControlImpl] Processing Unit ID: %u", _processingUnitID);
+        
+        _controlInterface = [self createControlInterface:_deviceInterface];
+        
+        if (_controlInterface == nullptr) {
+            NSLog(@"[UvcControlImpl] Failed to create control interface");
+            *status = STATUS_DEVICE_DISCONNECTED;
+            return nil;
+        }
+    }
+    return self;
+}
+
+- (void)dealloc {
+    if (_controlInterface != nullptr) {
+        (*_controlInterface)->USBInterfaceClose(_controlInterface);
+        (*_controlInterface)->Release(_controlInterface);
+    }
+    if (_deviceInterface != nullptr) {
+        (*_deviceInterface)->Release(_deviceInterface);
+    }
+}
+
+- (IOUSBDeviceInterface**)findDevice:(uint16_t)vid 
+                          productId:(uint16_t)pid 
+                          location:(uint32_t)location {
+    NSLog(@"[UvcControlImpl] findDevice: called");
+
+    CFMutableDictionaryRef dict = IOServiceMatching(kIOUSBDeviceClassName);
+    
+    io_iterator_t serviceIterator;
+    kern_return_t result = IOServiceGetMatchingServices((mach_port_t)NULL, dict, &serviceIterator);
+    if (result != kIOReturnSuccess) {
+        NSLog(@"[UvcControlImpl] findDevice: IOServiceGetMatchingServices failed: %d", result);
+        return nullptr;
+    }
+    
+    io_service_t device;
+    while((device = IOIteratorNext(serviceIterator)) != 0) {
+        IOUSBDeviceInterface **deviceInterface = nullptr;
+        IOCFPlugInInterface  **plugInInterface = nullptr;
+        SInt32 score;
+        
+        kern_return_t result = IOCreatePlugInInterfaceForService(
+            device, kIOUSBDeviceUserClientTypeID,
+            kIOCFPlugInInterfaceID, &plugInInterface, &score);
+            
+        if ((result != kIOReturnSuccess) || (plugInInterface == nullptr)) {
+            NSLog(@"[UvcControlImpl] findDevice: Camera control error: %d", result);
+            IOObjectRelease(device);
+            continue;
+        }
+        
+        HRESULT hr = (*plugInInterface)->QueryInterface(plugInInterface,
+            CFUUIDGetUUIDBytes(kIOUSBDeviceInterfaceID),
+            (LPVOID*)&deviceInterface);
+            
+        if (hr || (deviceInterface == nullptr)) {
+            (*plugInInterface)->Release(plugInInterface);
+            IOObjectRelease(device);
+            NSLog(@"[UvcControlImpl] findDevice: QueryInterface failed");
+            continue;
+        }
+        
+        uint16_t vendorID, productID;
+        uint32_t locationID;
+        result = (*deviceInterface)->GetDeviceVendor(deviceInterface, &vendorID);
+        result = (*deviceInterface)->GetDeviceProduct(deviceInterface, &productID);
+        result = (*deviceInterface)->GetLocationID(deviceInterface, &locationID);
+        
+        // if 'location' is zero, we won't match on location
+        // to achieve this, we simply set locationID to zero.
+        if (location == 0) {
+            locationID = 0;
+        }
+        
+        if ((vendorID == vid) && (productID == pid) && (locationID == location)) {
+            (*plugInInterface)->Release(plugInInterface);
+            IOObjectRelease(device);
+            IOObjectRelease(serviceIterator);
+            return deviceInterface;
+        }
+        
+        (*deviceInterface)->Release(deviceInterface);
+        (*plugInInterface)->Release(plugInInterface);
+        IOObjectRelease(device);
+    }
+    
+    IOObjectRelease(serviceIterator);
+    return nullptr;
+}
+
+- (uint32_t)getProcessingUnitID:(IOUSBDeviceInterface**)dev {
+    IOReturn kr;
+    IOUSBConfigurationDescriptorPtr configDesc;
+    
+    kr = (*dev)->GetConfigurationDescriptorPtr(dev, 0, &configDesc);
+    if (kr) {
+        return 0;
+    }
+
+    NSLog(@"[UvcControlImpl] getProcessingUnitID: USB descriptor:\n");
+    NSLog(@"  length    = %08X\n", configDesc->bLength);
+    NSLog(@"  type      = %08X\n", configDesc->bDescriptorType);
+    NSLog(@"  totalLen  = %08X\n", configDesc->wTotalLength);
+    NSLog(@"  interfaces = %08X\n", configDesc->bNumInterfaces);
+    
+    uint32_t idx = 0;
+    uint8_t *ptr = (uint8_t*)configDesc;
+
+    // Search for VIDEO/CONTROL interface descriptor
+    // Class=14, Subclass=1, Protocol=0
+    // and find the processing unit, if available..
+        // DescriptorType 0x24, DescriptorSubType 0x5
+
+    IOUSBInterfaceDescriptor *iface = NULL;
+    ProcessingUnitDescriptor *pud   = NULL;
+    bool inVideoControlInterfaceDescriptor = false;
+    while(idx < configDesc->wTotalLength) {
+        IOUSBDescriptorHeader *hdr = (IOUSBDescriptorHeader *)&ptr[idx];
+        switch(hdr->bDescriptorType)
+            {
+                case 0x05:  // Endpoint descriptor ID
+                    NSLog(@"[UvcControlImpl] getProcessingUnitID: Endpoint\n");
+                    break;
+                case 0x02:  // Configuration descriptor ID
+                    NSLog(@"[UvcControlImpl] getProcessingUnitID: Configuration\n");
+                    break;
+                case 0x04: // Interface descriptor ID
+                    NSLog(@"[UvcControlImpl] getProcessingUnitID: Interface");
+                    iface = (IOUSBInterfaceDescriptor*)&ptr[idx];
+                    if ((iface->bInterfaceClass == 14) && 
+                        (iface->bInterfaceSubClass == 1) &&
+                        (iface->bInterfaceProtocol == 0))
+                    {
+                        inVideoControlInterfaceDescriptor = true;
+                        NSLog(@" VIDEO/CONTROL\n");
+                    }
+                    else
+                    {
+                        inVideoControlInterfaceDescriptor = false;
+                        NSLog(@"\n");
+                    }
+                    break;
+                case 0x24: // class-specific ID
+                    pud = (ProcessingUnitDescriptor*)&ptr[idx];
+                    if (inVideoControlInterfaceDescriptor)
+                    {
+                        if (pud->bDescriptorSubtype == 0x05)
+                        {
+                            NSLog(@"Processing Unit ID: %d\n", 
+                                pud->bUnitID);
+                            return pud->bUnitID;
+                        }
+                    }
+                    //LOG(LOG_VERBOSE,"\n");
+                    break;
+                default:
+                    //LOG(LOG_VERBOSE,"?\n");
+                    break;
+            }
+        idx += hdr->bLength;
+    }
+    
+    return 0;
+}
+
+- (IOUSBInterfaceInterface190**)createControlInterface:(IOUSBDeviceInterface**)deviceInterface {
+    IOUSBInterfaceInterface190 **controlInterface;
+    
+    io_iterator_t interfaceIterator;
+    IOUSBFindInterfaceRequest interfaceRequest;
+    interfaceRequest.bInterfaceClass = UVC_CONTROL_INTERFACE_CLASS;
+    interfaceRequest.bInterfaceSubClass = UVC_CONTROL_INTERFACE_SUBCLASS;
+    interfaceRequest.bInterfaceProtocol = kIOUSBFindInterfaceDontCare;
+    interfaceRequest.bAlternateSetting = kIOUSBFindInterfaceDontCare;
+    
+    IOReturn result = (*deviceInterface)->CreateInterfaceIterator(deviceInterface,
+        &interfaceRequest, &interfaceIterator);
+        
+    if (result != kIOReturnSuccess) {
+        return nullptr;
+    }
+    
+    io_service_t usbInterface;
+    if ((usbInterface = IOIteratorNext(interfaceIterator)) != 0) {
+        IOCFPlugInInterface **plugInInterface = nullptr;
+        SInt32 score;
+        
+        kern_return_t kr = IOCreatePlugInInterfaceForService(usbInterface,
+            kIOUSBInterfaceUserClientTypeID,
+            kIOCFPlugInInterfaceID,
+            &plugInInterface,
+            &score);
+            
+        kr = IOObjectRelease(usbInterface);
+        if ((kr != kIOReturnSuccess) || !plugInInterface) {
+            NSLog(@"[UvcControlImpl] createControlInterface: cannot create plug-in %08X",
+                kr);
+            return nullptr;
+        }
+        
+        HRESULT hr = (*plugInInterface)->QueryInterface(plugInInterface,
+            CFUUIDGetUUIDBytes(kIOUSBInterfaceInterfaceID),
+            (LPVOID*) &controlInterface);
+            
+        (*plugInInterface)->Release(plugInInterface);
+        
+        if (hr || !controlInterface) {
+            NSLog(@"[UvcControlImpl] createControlInterface: cannot create device interface %08X",
+                result);
+            return nullptr;
+        }
+        
+        NSLog(@"[UvcControlImpl] createControlInterface: created control interface");
+        return controlInterface;
+    }
+    return nullptr;
+}
+
+- (bool)sendControlRequest:(IOUSBDevRequest)req {
+    if (_controlInterface == nullptr) {
+        NSLog(@"[UvcControlImpl] sendControlRequest: control interface is NULL");
+        return false;
+    }
+
+    kern_return_t kr;
+    if (@available(macOS 12.0, *)) {
+        // macOS 12 doesn't like if we're trying to open USB interface here...
+    } else {
+        kr = (*_controlInterface)->USBInterfaceOpen(_controlInterface);
+        if (kr != kIOReturnSuccess) {
+            NSLog(@"[UvcControlImpl] sendControlRequest: USBInterfaceOpen failed with error: 0x%08X", kr);
+            return false;
+        }
+    }
+
+    kr = (*_controlInterface)->ControlRequest(_controlInterface, 0, &req);
+    if (kr != kIOReturnSuccess) {
+        // IOKIT error code
+        #define err_get_system(err) (((err)>>26)&0x3f) 
+        #define err_get_sub(err) (((err)>>14)&0xfff) 
+        #define err_get_code(err) ((err)&0x3fff)
+        
+        uint32_t code = err_get_code(kr);
+        uint32_t sys  = err_get_system(kr);
+        uint32_t sub  = err_get_sub(kr);
+
+        switch(kr)
+        {
+            case kIOUSBUnknownPipeErr:
+                NSLog(@"[UvcControlImpl] sendControlRequest: Pipe ref not recognised");
+                break;
+            case kIOUSBTooManyPipesErr:
+                NSLog(@"[UvcControlImpl] sendControlRequest: Too many pipes");
+                break;
+            case kIOUSBEndpointNotFound:
+                NSLog(@"[UvcControlImpl] sendControlRequest: Endpoint not found");
+                break;
+            case kIOUSBConfigNotFound:
+                NSLog(@"[UvcControlImpl] sendControlRequest: USB configuration not found");
+                break;
+            case kIOUSBPipeStalled:
+                //Note: we don't report this as an error as this happens when
+                //      an unsupported or locked property is set.            
+                NSLog(@"[UvcControlImpl] sendControlRequest: Pipe has stalled, error needs to be cleared");
+                break;
+            case kIOUSBInterfaceNotFound:
+                NSLog(@"[UvcControlImpl] sendControlRequest: USB control interface not found");
+                break;
+            default:
+                NSLog(@"[UvcControlImpl] sendControlRequest: ControlRequest failed (KR=sys:sub:code) = %02Xh:%03Xh:%04Xh)", 
+                    sys, sub, code);
+                break; 
+        }
+
+        if (@available(macOS 12.0, *)) {
+            // macOS 12 doesn't like if we're trying to close USB interface here...
+        } else {
+            kr = (*_controlInterface)->USBInterfaceClose(_controlInterface);
+            if (kr != kIOReturnSuccess) {
+                NSLog(@"[UvcControlImpl] sendControlRequest: USBInterfaceClose failed");
+            }
+        }
+        return false;
+    }
+
+    if (@available(macOS 12.0, *)) {
+        // macOS 12 doesn't like if we're trying to close USB interface here either...
+    } else {
+        kr = (*_controlInterface)->USBInterfaceClose(_controlInterface);
+
+        if (kr != kIOReturnSuccess) {
+            NSLog(@"[UvcControlImpl] sendControlRequest: USBInterfaceClose failed");
+        }
+    }
+
+    return true;
+}
+
+- (bool)setData:(uint32_t)selector unit:(uint32_t)unit length:(uint32_t)length data:(int32_t)data {
+    IOUSBDevRequest req;
+    req.bmRequestType = USBmakebmRequestType((UInt8)kUSBOut, (UInt8)kUSBClass, (UInt8)kUSBInterface);
+    req.bRequest = UVC_SET_CUR;
+    req.wValue = (selector << 8);
+    req.wIndex = (unit << 8);
+    req.wLength = length;
+    req.wLenDone = 0;
+    req.pData = &data;
+    return [self sendControlRequest:req];
+}
+
+- (bool)getData:(uint32_t)selector unit:(uint32_t)unit length:(uint32_t)length data:(int32_t*)data {
+    IOUSBDevRequest req;
+    req.bmRequestType = USBmakebmRequestType((UInt8)kUSBIn, (UInt8)kUSBClass, (UInt8)kUSBInterface);
+    req.bRequest = UVC_GET_CUR;
+    req.wValue = (selector << 8);
+    req.wIndex = (unit << 8);
+    req.wLength = length;
+    req.wLenDone = 0;
+    req.pData = data;
+    return [self sendControlRequest:req];
+}
+
+- (bool)getMaxData:(uint32_t)selector unit:(uint32_t)unit length:(uint32_t)length data:(int32_t*)data {
+    IOUSBDevRequest req;
+    *data = 0;
+    req.bmRequestType = USBmakebmRequestType((UInt8)kUSBIn, (UInt8)kUSBClass, (UInt8)kUSBInterface);
+    req.bRequest = UVC_GET_MAX;
+    req.wValue = (selector << 8);
+    req.wIndex = (unit << 8);
+    req.wLength = length;
+    req.wLenDone = 0;
+    req.pData = data;
+    return [self sendControlRequest:req];
+}
+
+- (bool)getMinData:(uint32_t)selector unit:(uint32_t)unit length:(uint32_t)length data:(int32_t*)data {
+    IOUSBDevRequest req;
+    *data = 0;
+    req.bmRequestType = USBmakebmRequestType((UInt8)kUSBIn, (UInt8)kUSBClass, (UInt8)kUSBInterface);
+    req.bRequest = UVC_GET_MIN;
+    req.wValue = (selector << 8);
+    req.wIndex = (unit << 8);
+    req.wLength = length;
+    req.wLenDone = 0;
+    req.pData = data;
+    return [self sendControlRequest:req];
+}
+
+- (bool)getDefault:(uint32_t)selector unit:(uint32_t)unit length:(uint32_t)length data:(int32_t*)data {
+    IOUSBDevRequest req;
+    *data = 0;
+    req.bmRequestType = USBmakebmRequestType((UInt8)kUSBIn, (UInt8)kUSBClass, (UInt8)kUSBInterface);
+    req.bRequest = UVC_GET_DEF;
+    req.wValue = (selector << 8);
+    req.wIndex = (unit << 8);
+    req.wLength = length;
+    req.wLenDone = 0;
+    req.pData = data;
+    return [self sendControlRequest:req];
+}
+
+- (bool)getInfo:(uint32_t)selector unit:(uint32_t)unit data:(uint32_t*)data {
+    IOUSBDevRequest req;
+    *data = 0;
+    req.bmRequestType = USBmakebmRequestType((UInt8)kUSBIn, (UInt8)kUSBClass, (UInt8)kUSBInterface);
+    req.bRequest = UVC_GET_INFO;
+    req.wValue = (selector << 8);
+    req.wIndex = (unit << 8);
+    req.wLength = 1;
+    req.wLenDone = 0;
+    req.pData = data;
+    return [self sendControlRequest:req];
+}
+
+- (bool)setProperty:(uint32_t)propID withValue:(int32_t)value status:(CS_Status*)status {
+    if (_controlInterface == nullptr) {
+        NSLog(@"[UvcControlImpl] setProperty: control interface is NULL");
+        *status = STATUS_DEVICE_DISCONNECTED;
+        return false;
+    }
+
+    bool ok = false;
+    if (propID < CAPPROPID_LAST) {
+        uint32_t unit = (propertyInfo[propID].unit == 0) ? UVC_INPUT_TERMINAL_ID : _processingUnitID;
+        NSLog(@"[UvcControlImpl] Setting property %u to value %d (unit: %u)", propID, value, unit);
+        ok = [self setData:propertyInfo[propID].selector unit:unit length:propertyInfo[propID].length data:value];
+        if (!ok) {
+            NSLog(@"[UvcControlImpl] Failed to set property %u", propID);
+        }
+    } else {
+        NSLog(@"[UvcControlImpl] Invalid property ID: %u", propID);
+    }
+    return ok;
+}
+
+- (bool)getProperty:(uint32_t)propID withValue:(int32_t*)value status:(CS_Status*)status {
+    if (_controlInterface == nullptr) {
+        NSLog(@"[UvcControlImpl] getProperty: control interface is NULL");
+        *status = STATUS_DEVICE_DISCONNECTED;
+        return false;
+    }
+
+    bool ok = false;
+    if (propID < CAPPROPID_LAST) {
+        uint32_t unit = (propertyInfo[propID].unit == 0) ? UVC_INPUT_TERMINAL_ID : _processingUnitID;
+        NSLog(@"[UvcControlImpl] Getting property %u (unit: %u)", propID, unit);
+        ok = [self getData:propertyInfo[propID].selector unit:unit length:propertyInfo[propID].length data:value];
+
+        switch(propertyInfo[propID].length) {
+            case 2:
+                *value = static_cast<int16_t>(*value);
+                break;
+            case 1:
+                *value = static_cast<int8_t>(*value);
+                break;
+            default:
+                break;
+        }
+        if (ok) {
+            NSLog(@"[UvcControlImpl] Property %u value: %d", propID, *value);
+        } else {
+            NSLog(@"[UvcControlImpl] Failed to get property %u", propID);
+        }
+    } else {
+        NSLog(@"[UvcControlImpl] Invalid property ID: %u", propID);
+    }
+    return ok;
+}
+
+- (bool)setAutoProperty:(uint32_t)propID enabled:(bool)enabled status:(CS_Status*)status {
+    if (_controlInterface == nullptr) {
+        NSLog(@"[UvcControlImpl] setAutoProperty: control interface is NULL");
+        *status = STATUS_DEVICE_DISCONNECTED;
+        return false;
+    }
+
+    int32_t value = enabled ? 1 : 0;
+    switch(propID) {
+        case CAPPROPID_EXPOSURE:
+            NSLog(@"[UvcControlImpl] Setting auto property %u to %@", propID, enabled ? @"enabled" : @"disabled");
+            return [self setData:CT_AE_MODE_CONTROL unit:UVC_INPUT_TERMINAL_ID length:1 data:enabled ? 0x8 : 0x1];
+        case CAPPROPID_WHITEBALANCE:
+            NSLog(@"[UvcControlImpl] Setting auto property %u to %@", propID, enabled ? @"enabled" : @"disabled");
+            return [self setData:PU_WHITE_BALANCE_TEMPERATURE_AUTO_CONTROL unit:_processingUnitID length:1 data:value];
+        case CAPPROPID_FOCUS:
+            NSLog(@"[UvcControlImpl] Setting auto property %u to %@", propID, enabled ? @"enabled" : @"disabled");
+            return [self setData:CT_FOCUS_AUTO_CONTROL unit:UVC_INPUT_TERMINAL_ID length:1 data:value];
+        default:
+            return false;
+    }
+}
+
+- (bool)getAutoProperty:(uint32_t)propID enabled:(bool*)enabled status:(CS_Status*)status {
+    if (_controlInterface == nullptr) {
+        NSLog(@"[UvcControlImpl] getAutoProperty: control interface is NULL");
+        *status = STATUS_DEVICE_DISCONNECTED;
+        return false;
+    }
+
+    int32_t value;
+    NSLog(@"[UvcControlImpl] Getting auto property %u", propID);
+    
+    switch(propID) {
+        case CAPPROPID_EXPOSURE:
+            if ([self getData:CT_AE_MODE_CONTROL unit:UVC_INPUT_TERMINAL_ID length:1 data:&value]) {
+                NSLog(@"[UvcControlImpl] Exposure auto mode: %@", *enabled ? @"enabled" : @"disabled");
+                // value = 1 -> manual mode
+                //         2 -> auto mode (I haven't seen this in the wild)
+                //         4 -> shutter priority mode (haven't seen this)
+                //         8 -> aperature prioritry mode (seen this used)
+                value &= 0xFF;
+                *enabled = (value==1) ? false : true;
+                return true;
+            }
+            return false;
+        case CAPPROPID_WHITEBALANCE:
+            if ([self getData:PU_WHITE_BALANCE_TEMPERATURE_AUTO_CONTROL unit:_processingUnitID length:1 data:&value]) {
+                value &= 0xFF;
+                *enabled = (value==1) ? true : false;
+                NSLog(@"[UvcControlImpl] White balance auto mode: %@", *enabled ? @"enabled" : @"disabled");
+                return true;
+            }
+            return false;
+        case CAPPROPID_FOCUS:
+            if ([self getData:CT_FOCUS_AUTO_CONTROL unit:UVC_INPUT_TERMINAL_ID length:1 data:&value]) {
+                value &= 0xFF;
+                *enabled = (value==1) ? true : false;
+                NSLog(@"[UvcControlImpl] Focus auto mode: %@", *enabled ? @"enabled" : @"disabled");
+                return true;
+            }
+            return false;
+        default:
+            NSLog(@"[UvcControlImpl] Unsupported auto property ID: %u", propID);
+            return false;
+    }
+}
+
+- (bool)getPropertyLimits:(uint32_t)propID min:(int32_t*)min max:(int32_t*)max defValue:(int32_t*)defValue status:(CS_Status*)status {
+    if (_controlInterface == nullptr) {
+        *status = STATUS_DEVICE_DISCONNECTED;
+        return false;
+    }
+
+    bool ok = true;
+    if (propID < CAPPROPID_LAST) {
+        uint32_t unit = (propertyInfo[propID].unit == 0) ? UVC_INPUT_TERMINAL_ID : _processingUnitID;
+        
+        if (![self getMinData:propertyInfo[propID].selector unit:unit length:propertyInfo[propID].length data:min]) {
+            NSLog(@"[UvcControlImpl] getPropertyLimits: getMinData failed");
+            ok = false;
+        }
+
+        if (![self getMaxData:propertyInfo[propID].selector unit:unit length:propertyInfo[propID].length data:max]) {
+            NSLog(@"[UvcControlImpl] getPropertyLimits: getMaxData failed");
+            ok = false;
+        }
+
+        if (![self getDefault:propertyInfo[propID].selector unit:unit length:propertyInfo[propID].length data:defValue]) {
+            NSLog(@"[UvcControlImpl] getPropertyLimits: getDefault failed");
+            ok = false;
+        }
+
+        switch(propertyInfo[propID].length) {
+            case 2:
+                *min = static_cast<int16_t>(*min);
+                *max = static_cast<int16_t>(*max);
+                *defValue = static_cast<int16_t>(*defValue);
+                break;
+            case 1:
+                *min = static_cast<int8_t>(*min);
+                *max = static_cast<int8_t>(*max);
+                *defValue = static_cast<int8_t>(*defValue);
+                break;
+            default:
+                break;
+        }
+    } else {
+        NSLog(@"[UvcControlImpl] getPropertyLimits: property ID out of bounds");
+        ok = false;
+    }
+    return ok;
+}
+
+- (void)reportCapabilities:(uint32_t)selector unit:(uint32_t)unit {
+    uint32_t info;
+    [self getInfo:selector unit:unit data:&info];
+    if (info & 0x01) {
+        NSLog(@"GET ");
+    }
+    if (info & 0x02) {
+        NSLog(@"SET ");
+    }
+    if (info & 0x04) {
+        NSLog(@"DISABLED ");
+    }
+    if (info & 0x08) {
+        NSLog(@"AUTO-UPD ");
+    }
+    if (info & 0x10) {
+        NSLog(@"ASYNC ");
+    }
+    if (info & 0x20) {
+        NSLog(@"DISCOMMIT");
+    }
+    NSLog(@"\n");
+}
+
+@end 

--- a/cscore/src/main/native/objcpp/UvcControlImpl.mm
+++ b/cscore/src/main/native/objcpp/UvcControlImpl.mm
@@ -50,7 +50,7 @@ const propertyInfo_t propertyInfo[] =
 + (instancetype)createFromAVCaptureDevice:(AVCaptureDevice*)device status:(CS_Status*)status {
     if (!device) {
         NSLog(@"[UvcControlImpl] device is nil");
-        *status = STATUS_ERROR;
+        *status = CS_UVC_STATUS_ERROR;
         return nil;
     }
     
@@ -60,14 +60,14 @@ const propertyInfo_t propertyInfo[] =
                                                                            error:&error];
     if (error) {
         NSLog(@"[UvcControlImpl] failed to create regex: %@", error);
-        *status = STATUS_ERROR;
+        *status = CS_UVC_STATUS_ERROR;
         return nil;
     }
     
     NSString* modelID = [device valueForKey:@"modelID"];
     if (!modelID) {
         NSLog(@"[UvcControlImpl] modelID is nil");
-        *status = STATUS_ERROR;
+        *status = CS_UVC_STATUS_ERROR;
         return nil;
     }
     
@@ -76,7 +76,7 @@ const propertyInfo_t propertyInfo[] =
                                                      range:NSMakeRange(0, modelID.length)];
     if (!match || match.numberOfRanges != 3) {
         NSLog(@"[UvcControlImpl] modelID regex match failed");
-        *status = STATUS_ERROR;
+        *status = CS_UVC_STATUS_ERROR;
         return nil;
     }
     
@@ -135,7 +135,7 @@ const propertyInfo_t propertyInfo[] =
         _deviceInterface = [self findDevice:vid productId:pid location:location];
         if (_deviceInterface == nullptr) {
             NSLog(@"[UvcControlImpl] Failed to find device");
-            *status = STATUS_DEVICE_DISCONNECTED;
+            *status = CS_UVC_STATUS_DEVICE_DISCONNECTED;
             return nil;
         }
         
@@ -146,7 +146,7 @@ const propertyInfo_t propertyInfo[] =
         
         if (_controlInterface == nullptr) {
             NSLog(@"[UvcControlImpl] Failed to create control interface");
-            *status = STATUS_DEVICE_DISCONNECTED;
+            *status = CS_UVC_STATUS_DEVICE_DISCONNECTED;
             return nil;
         }
     }
@@ -519,7 +519,7 @@ const propertyInfo_t propertyInfo[] =
 - (bool)setProperty:(uint32_t)propID withValue:(int32_t)value status:(CS_Status*)status {
     if (_controlInterface == nullptr) {
         NSLog(@"[UvcControlImpl] setProperty: control interface is NULL");
-        *status = STATUS_DEVICE_DISCONNECTED;
+        *status = CS_UVC_STATUS_DEVICE_DISCONNECTED;
         return false;
     }
 
@@ -540,7 +540,7 @@ const propertyInfo_t propertyInfo[] =
 - (bool)getProperty:(uint32_t)propID withValue:(int32_t*)value status:(CS_Status*)status {
     if (_controlInterface == nullptr) {
         NSLog(@"[UvcControlImpl] getProperty: control interface is NULL");
-        *status = STATUS_DEVICE_DISCONNECTED;
+        *status = CS_UVC_STATUS_DEVICE_DISCONNECTED;
         return false;
     }
 
@@ -574,7 +574,7 @@ const propertyInfo_t propertyInfo[] =
 - (bool)setAutoProperty:(uint32_t)propID enabled:(bool)enabled status:(CS_Status*)status {
     if (_controlInterface == nullptr) {
         NSLog(@"[UvcControlImpl] setAutoProperty: control interface is NULL");
-        *status = STATUS_DEVICE_DISCONNECTED;
+        *status = CS_UVC_STATUS_DEVICE_DISCONNECTED;
         return false;
     }
 
@@ -597,7 +597,7 @@ const propertyInfo_t propertyInfo[] =
 - (bool)getAutoProperty:(uint32_t)propID enabled:(bool*)enabled status:(CS_Status*)status {
     if (_controlInterface == nullptr) {
         NSLog(@"[UvcControlImpl] getAutoProperty: control interface is NULL");
-        *status = STATUS_DEVICE_DISCONNECTED;
+        *status = CS_UVC_STATUS_DEVICE_DISCONNECTED;
         return false;
     }
 
@@ -641,7 +641,7 @@ const propertyInfo_t propertyInfo[] =
 
 - (bool)getPropertyLimits:(uint32_t)propID min:(int32_t*)min max:(int32_t*)max defValue:(int32_t*)defValue status:(CS_Status*)status {
     if (_controlInterface == nullptr) {
-        *status = STATUS_DEVICE_DISCONNECTED;
+        *status = CS_UVC_STATUS_DEVICE_DISCONNECTED;
         return false;
     }
 

--- a/cscore/src/main/native/objcpp/UvcControlImpl.mm
+++ b/cscore/src/main/native/objcpp/UvcControlImpl.mm
@@ -2,6 +2,28 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
+// Copyright (c) 2017 Jason von Nieda, Niels Moseley
+//
+// The MIT License (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 #import "UvcControlImpl.h"
 #import <AVFoundation/AVFoundation.h>
 

--- a/cscore/src/main/native/objcpp/UvcControlImpl.mm
+++ b/cscore/src/main/native/objcpp/UvcControlImpl.mm
@@ -24,8 +24,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#import "UvcControlImpl.h"
 #import <AVFoundation/AVFoundation.h>
+
+#import "UvcControlImpl.h"
 
 #include "Log.h"
 #include "UsbCameraImpl.h"

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -32,6 +32,13 @@ nativeUtils.enableSourceLink()
 
 nativeUtils.wpi.addMacMinimumVersionArg()
 
+nativeUtils.platformConfigs.each {
+    if (it.name.contains('osx')) {
+        it.linker.getArgs().add('-framework')
+        it.linker.getArgs().add('IOKit')
+    }
+}
+
 // Compress debug info on Linux
 nativeUtils.platformConfigs.each {
   if (it.name.contains('linux')) {


### PR DESCRIPTION
## Overview
This MR enhances the cscore project on macOS by implementing UVC (USB Video Class) protocol communication for USB cameras, while also fixing a frame rate precision issue in the AVCaptureDevice configuration.

## Key Changes

### 1. UVC Protocol Implementation
- Added UVC protocol support for USB cameras on macOS
- Implemented common camera property controls through UVC protocol:
  - Exposure
  - Brightness
  - White Balance
  - And other standard UVC properties
- The original implementation was insipred from [openpnp-capture](https://github.com/openpnp/openpnp-capture/blob/master/mac/uvcctrl.mm)

### 2. Frame Rate Precision Fix
- Fixed frame rate precision loss when configuring AVCaptureDevice camera FPS on macOS
- Implemented a matching algorithm to:
  - Take the requested FPS value as input
  - Find the closest supported hardware frame duration
  - Apply the matched frame duration to ensure accurate frame rate setting
- This should fix #7893

## Testing
- Tested with various UVC-compliant USB cameras
- Verified frame rate precision with different FPS settings
- Confirmed backward compatibility with non-UVC devices
- Validated error handling for unsupported features

## Known Limitations
- UVC controls are only available for USB cameras that implement the UVC protocol
- Built-in cameras and virtual cameras will not support advanced controls
- Some USB cameras might have vendor-specific implementations that differ from standard UVC protocol

## Future Considerations
- Additional camera quirks support based on user feedback